### PR TITLE
Release version 1

### DIFF
--- a/examples/client/forms.main.lfm
+++ b/examples/client/forms.main.lfm
@@ -1,7 +1,7 @@
 object Form1: TForm1
-  Left = 745
+  Left = 808
   Height = 491
-  Top = 132
+  Top = 140
   Width = 372
   Caption = 'Form1'
   ChildSizing.LeftRightSpacing = 5
@@ -14,37 +14,39 @@ object Form1: TForm1
   ClientWidth = 372
   LCLVersion = '3.99.0.0'
   OnCreate = FormCreate
-  object ButtonNextScreen: TButton
-    Left = 5
-    Height = 25
-    Top = 5
-    Width = 176
-    Caption = 'Select Next Screen'
-    TabOrder = 7
-    OnClick = ButtonNextScreenClick
-  end
   object CheckBoxUseRemoteServer: TCheckBox
-    Left = 186
-    Height = 25
+    Left = 5
+    Height = 23
     Top = 5
-    Width = 181
-    Caption = 'Using Remote Server'
+    Width = 192
+    Caption = 'Use Remote Server'
     TabOrder = 10
+    OnChange = CheckBoxUseRemoteServerChange
+  end
+  object EditIP: TEdit
+    Left = 202
+    Height = 23
+    Top = 5
+    Width = 165
+    Enabled = False
+    TabOrder = 12
+    Text = '127.0.0.1'
+    TextHint = 'IP'
   end
   object ButtonConnect: TButton
     Left = 5
     Height = 25
-    Top = 30
-    Width = 176
+    Top = 28
+    Width = 192
     Caption = 'Connect'
     TabOrder = 0
     OnClick = ButtonConnectClick
   end
   object ButtonDisconnect: TButton
-    Left = 186
+    Left = 202
     Height = 25
-    Top = 30
-    Width = 181
+    Top = 28
+    Width = 165
     Caption = 'Disconnect'
     TabOrder = 1
     OnClick = ButtonDisconnectClick
@@ -52,17 +54,17 @@ object Form1: TForm1
   object ButtonStartRecording: TButton
     Left = 5
     Height = 25
-    Top = 55
-    Width = 176
+    Top = 53
+    Width = 192
     Caption = 'Start Recording'
     TabOrder = 2
     OnClick = ButtonStartRecordingClick
   end
   object ButtonStopRecording: TButton
-    Left = 186
+    Left = 202
     Height = 25
-    Top = 55
-    Width = 181
+    Top = 53
+    Width = 165
     Caption = 'Stop Recording'
     TabOrder = 3
     OnClick = ButtonStopRecordingClick
@@ -70,17 +72,17 @@ object Form1: TForm1
   object ButtonShowCalibration: TButton
     Left = 5
     Height = 25
-    Top = 80
-    Width = 176
+    Top = 78
+    Width = 192
     Caption = 'Show Calibration'
     TabOrder = 8
     OnClick = ButtonShowCalibrationClick
   end
   object ButtonHideCalibration: TButton
-    Left = 186
+    Left = 202
     Height = 25
-    Top = 80
-    Width = 181
+    Top = 78
+    Width = 165
     Caption = 'Hide Calibration'
     TabOrder = 9
     OnClick = ButtonHideCalibrationClick
@@ -88,25 +90,25 @@ object Form1: TForm1
   object ButtonStartCalibration: TButton
     Left = 5
     Height = 25
-    Top = 105
-    Width = 176
+    Top = 103
+    Width = 192
     Caption = 'Start Calibration'
     TabOrder = 4
     OnClick = ButtonStartCalibrationClick
   end
   object ButtonStopCalibration: TButton
-    Left = 186
+    Left = 202
     Height = 25
-    Top = 105
-    Width = 181
+    Top = 103
+    Width = 165
     Caption = 'Stop Calibration'
     TabOrder = 6
     OnClick = ButtonStopCalibrationClick
   end
   object ListBox1: TListBox
     Left = 5
-    Height = 332
-    Top = 154
+    Height = 278
+    Top = 208
     Width = 362
     Align = alBottom
     ItemHeight = 0
@@ -116,15 +118,34 @@ object Form1: TForm1
   object ButtonFlush: TButton
     Left = 5
     Height = 25
-    Top = 130
-    Width = 176
-    Caption = 'Flush'
+    Top = 128
+    Width = 192
+    Caption = 'Flush Received Data'
     TabOrder = 11
     OnClick = ButtonFlushClick
   end
+  object ButtonNextScreen: TButton
+    Left = 202
+    Height = 25
+    Top = 128
+    Width = 165
+    Caption = 'Select Next Screen'
+    TabOrder = 7
+    OnClick = ButtonNextScreenClick
+  end
+  object CheckBoxUseCustomCalibration: TCheckBox
+    Left = 5
+    Height = 19
+    Top = 153
+    Width = 192
+    Caption = 'Use Custom Calibration'
+    Checked = True
+    State = cbChecked
+    TabOrder = 13
+  end
   object PopupMenu1: TPopupMenu
-    Left = 336
-    Top = 104
+    Left = 320
+    Top = 192
     object MenuItemSaveToFile: TMenuItem
       Caption = 'Save To File'
       OnClick = MenuItemSaveToFileClick

--- a/examples/client/forms.main.pas
+++ b/examples/client/forms.main.pas
@@ -32,7 +32,9 @@ type
     ButtonStartRecording: TButton;
     ButtonStopRecording: TButton;
     ButtonStartCalibration: TButton;
+    CheckBoxUseCustomCalibration: TCheckBox;
     CheckBoxUseRemoteServer: TCheckBox;
+    EditIP: TEdit;
     ListBox1: TListBox;
     MenuItemSaveToFile: TMenuItem;
     PopupMenu1: TPopupMenu;
@@ -46,6 +48,7 @@ type
     procedure ButtonStartRecordingClick(Sender: TObject);
     procedure ButtonStopCalibrationClick(Sender: TObject);
     procedure ButtonStopRecordingClick(Sender: TObject);
+    procedure CheckBoxUseRemoteServerChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure MenuItemSaveToFileClick(Sender: TObject);
   private
@@ -104,39 +107,46 @@ end;
 procedure TForm1.ButtonStartCalibrationClick(Sender: TObject);
 begin
   OpenGazeControl.Calibration.UseCustomChoreography :=
-    CheckBoxUseRemoteServer.Checked;
-  OpenGazeControl.Calibration.Show;
-  OpenGazeControl.Calibration.Start;
+    CheckBoxUseCustomCalibration.Checked;
+  OpenGazeControl.IP := EditIP.Text;
+
+  OpenGazeControl.StartCalibration;
 end;
 
 procedure TForm1.ButtonStartRecordingClick(Sender: TObject);
 begin
-  OpenGazeControl.Recording.Start;
+  OpenGazeControl.StartRecording;
 end;
 
 procedure TForm1.ButtonStopCalibrationClick(Sender: TObject);
 begin
-  OpenGazeControl.Calibration.Stop;
+  OpenGazeControl.StopCalibration;
 end;
 
 procedure TForm1.ButtonStopRecordingClick(Sender: TObject);
 begin
-  OpenGazeControl.Recording.Stop;
+  OpenGazeControl.StopRecording;
+end;
+
+procedure TForm1.CheckBoxUseRemoteServerChange(Sender: TObject);
+begin
+  if CheckBoxUseRemoteServer.Checked then begin
+    //EditIP.Text := '169.254.150.247';
+    CheckBoxUseCustomCalibration.Checked := True;
+    CheckBoxUseCustomCalibration.Enabled := False;
+    EditIP.Enabled := True;
+  end else begin
+    CheckBoxUseCustomCalibration.Enabled := True;
+    EditIP.Text := '127.0.0.1';
+    EditIP.Enabled := False;
+  end;
 end;
 
 procedure TForm1.FormCreate(Sender: TObject);
 begin
-  //OpenGazeControl.Events.OnStartCalibration := @UpdateList;
-  //OpenGazeControl.Events.OnEnableSendData := @UpdateList;
-  //OpenGazeControl.Events.OnDisableSendData := @UpdateList;
-  //OpenGazeControl.Events.OnCalibrationPointResult := @UpdateList;
-  //OpenGazeControl.Events.OnCalibrationPointStart := @UpdateList;
-  //OpenGazeControl.Events.OnStartRecording := @UpdateList;
-  //OpenGazeControl.Events.OnStopRecording := @UpdateList;
   OpenGazeControl.Calibration.OnResult := @UpdateList;
   OpenGazeControl.Calibration.OnFailed := @CalibrationFailed;
   OpenGazeControl.Calibration.OnSuccess := @CalibrationSuccess;
-  OpenGazeControl.IP := '169.254.150.247';
 end;
 
 procedure TForm1.MenuItemSaveToFileClick(Sender: TObject);
@@ -155,10 +165,12 @@ end;
 
 procedure TForm1.CalibrationFailed(Sender: TObject);
 begin
-  OpenGazeControl.Calibration.Stop;
+  if OpenGazeControl.Calibration.UseCustomChoreography then begin
+    OpenGazeControl.StopCalibration;
+  end;
 
   Inc(FailedCalibrations);
-  if FailedCalibrations > 4 then begin
+  if FailedCalibrations > 2 then begin
     Exit;
   end else begin
     ButtonStartCalibrationClick(Sender);

--- a/examples/client/opengaze_client.lpi
+++ b/examples/client/opengaze_client.lpi
@@ -12,7 +12,6 @@
       <XPManifest>
         <DpiAware Value="True"/>
       </XPManifest>
-      <Icon Value="0"/>
     </General>
     <BuildModes>
       <Item Name="Debug" Default="True"/>
@@ -123,9 +122,6 @@
     </Linking>
     <Other>
       <CustomOptions Value="-dDEBUG"/>
-      <OtherDefines Count="1">
-        <Define0 Value="DEBUG"/>
-      </OtherDefines>
     </Other>
   </CompilerOptions>
   <Debugging>

--- a/src/opengaze.base.pas
+++ b/src/opengaze.base.pas
@@ -31,6 +31,7 @@ type
     FEvents : TOpenGazeEvents;
     procedure SendCommand(Command: string; Blocking : Boolean = True);
     function RequestCommand(Command: string) : TPairsDictionary;
+    function RequestKey(Command: string; Key: string): string;
   public
     constructor Create(ASocket: TOpenGazeSocket; AEvents: TOpenGazeEvents);
     property Socket : TOpenGazeSocket read FSocket;
@@ -70,6 +71,18 @@ begin
   FSocket.Request(Command, Reply);
   FEvents.ProcessTag(Self, Reply);
   Result := TagPairsToDict(Reply.Pairs);
+end;
+
+function TOpenGazeBase.RequestKey(Command: string; Key: string): string;
+var
+  Dictionary : TPairsDictionary;
+begin
+  Dictionary := RequestCommand(Command);
+  try
+    Result := Dictionary[Key];
+  finally
+    Dictionary.Free;
+  end;
 end;
 
 constructor TOpenGazeBase.Create(ASocket: TOpenGazeSocket;

--- a/src/opengaze.calibration.pas
+++ b/src/opengaze.calibration.pas
@@ -50,6 +50,7 @@ type
       procedure StartPointAnimation(Sender : TObject; Event : TPairsDictionary);
       procedure EndPointTimeout(Sender : TObject; Event : TPairsDictionary);
       procedure DoCalibrationResult(Sender: TObject; Event : TPairsDictionary);
+      procedure DoNothing(Sender: TObject; Event : TPairsDictionary);
     public
       constructor Create(ASocket : TOpenGazeSocket; AEvents : TOpenGazeEvents);
       destructor Destroy; override;
@@ -133,9 +134,8 @@ end;
 
 procedure TOpenGazeCalibration.SetOnResult(AValue: TOpenGazeEvent);
 begin
-  if FEvents = nil then Exit;
-  if FEvents.OnCalibrationResult = AValue then Exit;
-  FEvents.OnCalibrationResult := AValue;
+  if FOnResult = AValue then Exit;
+  FOnResult := AValue;
 end;
 
 procedure TOpenGazeCalibration.SetOnResultSummary(AValue: TOpenGazeEvent);
@@ -201,14 +201,20 @@ begin
   end;
 end;
 
+procedure TOpenGazeCalibration.DoNothing(Sender: TObject;
+  Event: TPairsDictionary);
+begin
+  { do nothing }
+end;
+
 constructor TOpenGazeCalibration.Create(ASocket: TOpenGazeSocket;
   AEvents: TOpenGazeEvents);
 begin
   inherited Create(ASocket, AEvents);
   FBlocking := True;
   FLoggerAlive := False;
-  FEvents.OnCalibrationPointStart := nil;
-  FEvents.OnCalibrationPointResult := nil;
+  FEvents.OnCalibrationPointStart := @DoNothing;
+  FEvents.OnCalibrationPointResult := @DoNothing;
   FEvents.OnCalibrationResult := @DoCalibrationResult;
 
   FPoints := TOpenGazeCalibrationPoints.Create(ASocket, AEvents);

--- a/src/opengaze.client.pas
+++ b/src/opengaze.client.pas
@@ -39,6 +39,7 @@ type
     destructor Destroy; override;
     procedure Connect;
     procedure Disconnect;
+    function Connected : Boolean;
     property Events : TOpenGazeEvents read FEvents;
   end;
 
@@ -113,6 +114,11 @@ begin
     FIncomingThread := nil;
   end;
   FSocket.Disconnect;
+end;
+
+function TOpenGazeBaseClient.Connected: Boolean;
+begin
+  Result := FSocket.Connected;
 end;
 
 end.

--- a/src/opengaze.commands.pas
+++ b/src/opengaze.commands.pas
@@ -98,6 +98,19 @@ type
     function DisableSendUserData : string;
   end;
 
+  // read only
+
+  { TInformationCommands }
+
+  TInformationCommands = record
+    function TimeTickFrequency : string;
+    function CameraSize : string;
+    function ProductID : string;
+    function SerialID : string;
+    function CompanyID : string;
+    function APIID : string;
+  end;
+
   { TRecordingCommandsOpenGazeAnalysis }
 
   TRecordingCommandsOpenGazeAnalysis = record
@@ -111,6 +124,7 @@ type
 var
   Calibration : TCalibrationCommands;
   Recording : TRecordingCommands;
+  Information : TInformationCommands;
   RecordingOpenGazeAnalysis : TRecordingCommandsOpenGazeAnalysis;
 
 implementation
@@ -284,12 +298,12 @@ end;
 
 function TCalibrationCommands.SetReset: string;
 begin
-  Result := ParseStr(CLIENT_GET, CALIBRATE_RESET, []);
+  Result := ParseStr(CLIENT_SET, CALIBRATE_RESET, []);
 end;
 
 function TCalibrationCommands.GetReset: string;
 begin
-  Result := ParseStr(CLIENT_SET, CALIBRATE_RESET, []);
+  Result := ParseStr(CLIENT_GET, CALIBRATE_RESET, []);
 end;
 
 function TCalibrationCommands.AddPoint(X, Y: Float): string;
@@ -615,6 +629,38 @@ function TRecordingCommands.DisableSendUserData: string;
 begin
   Result := ParseStr(CLIENT_SET, ENABLE_SEND_USER_DATA, False.ToStateArray);
   EnabledSendDataCommands := EnabledSendDataCommands-[TOpenGazeID.ENABLE_SEND_USER_DATA];
+end;
+
+{ TInformationCommands }
+
+function TInformationCommands.TimeTickFrequency: string;
+begin
+  Result := ParseStr(CLIENT_GET, TIME_TICK_FREQUENCY, []);
+end;
+
+function TInformationCommands.CameraSize: string;
+begin
+  Result := ParseStr(CLIENT_GET, CAMERA_SIZE, []);
+end;
+
+function TInformationCommands.ProductID: string;
+begin
+  Result := ParseStr(CLIENT_GET, PRODUCT_ID, []);
+end;
+
+function TInformationCommands.SerialID: string;
+begin
+  Result := ParseStr(CLIENT_GET, SERIAL_ID, []);
+end;
+
+function TInformationCommands.CompanyID: string;
+begin
+  Result := ParseStr(CLIENT_GET, COMPANY_ID, []);
+end;
+
+function TInformationCommands.APIID: string;
+begin
+  Result := ParseStr(CLIENT_GET, API_ID, []);
 end;
 
 { TRecordingCommandsOpenGazeAnalysis }

--- a/src/opengaze.constants.pas
+++ b/src/opengaze.constants.pas
@@ -50,8 +50,11 @@ const
   CALX = 'CALX'; // Parameter type: Numeric
   CALY = 'CALY'; // Parameter type: Numeric
   PTS = 'PTS'; // Parameter type: Numeric
+  FREQ = 'FREQ';
   XCOORDENATE = 'X';
   YCOORDENATE = 'Y';
+  CAMERA_WIDTH = 'WIDTH';
+  CAMERA_HEIGHT = 'HEIGHT';
   SCREEN_WIDTH = 'WIDTH';
   SCREEN_HEIGHT = 'HEIGHT';
   AVE_ERROR = 'AVE_ERROR';  // Parameter type: Numeric

--- a/src/opengaze.control.pas
+++ b/src/opengaze.control.pas
@@ -17,6 +17,7 @@ uses
   Classes, SysUtils,
   opengaze.types,
   opengaze.client,
+  opengaze.information,
   opengaze.calibration,
   opengaze.recording,
   opengaze.events;
@@ -27,18 +28,29 @@ type
 
   TOpenGazeControlClient = class(TOpenGazeBaseClient)
   private
+    FInformation : TOpenGazeInformation;
     FCalibration : TOpenGazeCalibration;
     FRecording   : TOpenGazeRecording;
     function GetIP: string;
+    function GetIsLocal: Boolean;
+    function GetProductID: string;
     procedure SetIP(AValue: string);
   public
     constructor Create;
     destructor Destroy; override;
     procedure StartCalibration;
+    procedure StopCalibration;
+    procedure SetupForRemoteServer;
+    procedure SetupDataFiles(AFilename : string);
+    procedure StartRecording;
+    procedure StopRecording;
     property Events : TOpenGazeEvents read FEvents;
     property Calibration : TOpenGazeCalibration read FCalibration;
     property Recording : TOpenGazeRecording read FRecording;
+    property Information : TOpenGazeInformation read FInformation;
     property IP : string read GetIP write SetIP;
+    property IsLocal : Boolean read GetIsLocal;
+    property ProductID : string read GetProductID;
   end;
 
 
@@ -47,6 +59,16 @@ implementation
 function TOpenGazeControlClient.GetIP: string;
 begin
   Result := FSocket.IP;
+end;
+
+function TOpenGazeControlClient.GetIsLocal: Boolean;
+begin
+  Result := FSocket.IsLocal;
+end;
+
+function TOpenGazeControlClient.GetProductID: string;
+begin
+  Result := Information.ProductID;
 end;
 
 procedure TOpenGazeControlClient.SetIP(AValue: string);
@@ -60,12 +82,14 @@ constructor TOpenGazeControlClient.Create;
 begin
   inherited Create;
   FSocket.Server := OpenGazeControlServer;
+  FInformation := TOpenGazeInformation.Create(FSocket, FEvents);
   FCalibration := TOpenGazeCalibration.Create(FSocket, FEvents);
   FRecording := TOpenGazeRecording.Create(FSocket, FEvents);
 end;
 
 destructor TOpenGazeControlClient.Destroy;
 begin
+  FInformation.Free;
   FRecording.Free;
   FCalibration.Free;
   inherited Destroy;
@@ -75,6 +99,37 @@ procedure TOpenGazeControlClient.StartCalibration;
 begin
   Calibration.Show;
   Calibration.Start;
+end;
+
+procedure TOpenGazeControlClient.StopCalibration;
+begin
+  Calibration.Stop;
+  Calibration.Hide;
+end;
+
+procedure TOpenGazeControlClient.SetupForRemoteServer;
+begin
+  Calibration.UseCustomChoreography := True;
+end;
+
+procedure TOpenGazeControlClient.SetupDataFiles(AFilename: string);
+begin
+  Information.SetupDataFile(AFilename);
+  Calibration.SetupDataFile(AFilename);
+  Recording.SetupDataFile(AFilename);
+end;
+
+procedure TOpenGazeControlClient.StartRecording;
+begin
+  Information.SaveToFile;
+  Calibration.StartLogger;
+  Recording.Start;
+end;
+
+procedure TOpenGazeControlClient.StopRecording;
+begin
+  Recording.Stop;
+  Calibration.StopLogger;
 end;
 
 end.

--- a/src/opengaze.events.pas
+++ b/src/opengaze.events.pas
@@ -71,7 +71,7 @@ type
 
 implementation
 
-uses OpenGaze.commands, OpenGaze.parser, OpenGaze.logger;
+uses opengaze.commands, opengaze.parser;
 
 { TOpenGazeEvents }
 
@@ -146,7 +146,6 @@ begin
 
     REC : begin
       { implement data logger events here }
-      LogLine(RawTag.Pairs);
       FOnDataReceived(Self, RawTag);
     end;
 

--- a/src/opengaze.helpers.pas
+++ b/src/opengaze.helpers.pas
@@ -26,6 +26,7 @@ type
     function ToValueArray : TStringArray;
     function ToXArray : TStringArray;
     function ToYArray : TStringArray;
+    function ToDefaultString : string;
   end;
 
   { TBooleanOpenGazeHelper }
@@ -74,6 +75,11 @@ end;
 function TFloatOpenGazeHelper.ToYArray: TStringArray;
 begin
   Result := [YCOORDENATE, Self.ToString(FormatSettings)];
+end;
+
+function TFloatOpenGazeHelper.ToDefaultString: string;
+begin
+  Result := Self.ToString(FormatSettings);
 end;
 
 { TBooleanOpenGazeHelper }

--- a/src/opengaze.information.pas
+++ b/src/opengaze.information.pas
@@ -1,0 +1,145 @@
+{
+  fpc-opengaze
+  Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU General Public License (GPL v3.0).
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit opengaze.information;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, blcksock,
+  opengaze.base,
+  opengaze.socket,
+  opengaze.events,
+  opengaze.types;
+
+type
+
+  { TOpenGazeInformation }
+
+  // A wrapper around outgoing information messages
+  TOpenGazeInformation = class(TOpenGazeBase)
+  private
+    function GetProductID: string;
+    public
+      constructor Create(ASocket : TOpenGazeSocket; AEvents : TOpenGazeEvents);
+      procedure SaveToFile;
+      procedure SetupDataFile(AFilename : string);
+      property ProductID : string read GetProductID;
+  end;
+
+implementation
+
+uses
+  opengaze.constants,
+  opengaze.commands,
+  opengaze.helpers,
+  opengaze.logger.information;
+
+{ TOpenGazeInformation }
+
+function TOpenGazeInformation.GetProductID: string;
+var
+  Dictionary: TPairsDictionary;
+begin
+  Dictionary := RequestCommand(Information.ProductID);
+  try
+    Result := Dictionary[VALUE];
+  finally
+    Dictionary.Free;
+  end;
+end;
+
+constructor TOpenGazeInformation.Create(ASocket: TOpenGazeSocket;
+  AEvents: TOpenGazeEvents);
+begin
+  inherited Create(ASocket, AEvents);
+end;
+
+procedure TOpenGazeInformation.SaveToFile;
+var
+  Dictionary : TPairsDictionary;
+
+  TimeTickFrequency : string = '';
+  CameraWidth : string = '';
+  CameraHeight : string = '';
+  LProductID : string = '';
+  ProductBus : string = '';
+  ProductRate : string = '';
+  SerialID : string = '';
+  CompanyID : string = '';
+  APIID : string = '';
+
+begin
+  Dictionary := RequestCommand(Information.TimeTickFrequency);
+  try
+    TimeTickFrequency := Dictionary[FREQ];
+  finally
+    Dictionary.Free;
+  end;
+
+  Dictionary := RequestCommand(Information.CameraSize);
+  try
+    CameraWidth := Dictionary[CAMERA_WIDTH];
+    CameraHeight := Dictionary[CAMERA_HEIGHT];
+  finally
+    Dictionary.Free;
+  end;
+
+  Dictionary := RequestCommand(Information.ProductID);
+  try
+    LProductID := Dictionary[VALUE];
+    ProductBus := Dictionary[BUS];
+    ProductRate := Dictionary[RATE];
+  finally
+    Dictionary.Free;
+  end;
+
+  Dictionary := RequestCommand(Information.SerialID);
+  try
+    SerialID := Dictionary[VALUE];
+  finally
+    Dictionary.Free;
+  end;
+
+  Dictionary := RequestCommand(Information.CompanyID);
+  try
+    CompanyID := Dictionary[VALUE];
+  finally
+    Dictionary.Free;
+  end;
+
+  Dictionary := RequestCommand(Information.APIID);
+  try
+    APIID := Dictionary[VALUE];
+  finally
+    Dictionary.Free;
+  end;
+
+  BeginUpdateData;
+  LogLine('ClientVersion', '1');
+  LogLine('TimeTickFrequency', TimeTickFrequency);
+  LogLine('CameraWidth', CameraWidth);
+  LogLine('CameraHeight', CameraHeight);
+  LogLine('ProductID', LProductID);
+  LogLine('ProductBus', ProductBus);
+  LogLine('ProductRate', ProductRate);
+  LogLine('SerialID', SerialID);
+  LogLine('CompanyID', CompanyID);
+  LogLine('APIID', APIID);
+  EndUpdateData;
+end;
+
+procedure TOpenGazeInformation.SetupDataFile(AFilename: string);
+begin
+  DataFilename := AFilename + '.gaze.info';
+end;
+
+end.

--- a/src/opengaze.logger.calibration.pas
+++ b/src/opengaze.logger.calibration.pas
@@ -1,0 +1,122 @@
+{
+  fpc-opengaze
+  Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU General Public License (GPL v3.0).
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit opengaze.logger.calibration;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, opengaze.types, choreographies;
+
+procedure LogLine(Pairs : TTagPairs); overload;
+procedure LogLine(Dictionary : TPairsDictionary); overload;
+procedure LogLine(Points : TNormalizedPoints); overload;
+function ToPythonDict(Dict: TPairsDictionary): string; overload;
+function ToPythonDict(Points: TNormalizedPoints): string; overload;
+procedure BeginUpdateData;
+procedure EndUpdateData;
+procedure FlushToDataFile;
+
+var
+  DataHeader : string;
+  DataFilename : string = 'default_calibration_log.txt';
+
+implementation
+
+uses opengaze.helpers;
+
+const
+  TabDelimiter = #9;
+
+var
+  OutputDataFile : TextFile;
+
+function ToPythonDict(Dict: TPairsDictionary): string;
+var
+  Key: string;
+  StringArray : TStringArray = nil;
+  i : integer = 0;
+begin
+  SetLength(StringArray, Dict.Count);
+  for Key in Dict.Keys do begin
+    StringArray[i] := Format('%s:%s', [Key, Dict[Key]]);
+    Inc(i);
+  end;
+
+  Result := '{' + String.Join(',', StringArray) + '}';
+end;
+
+
+function ToPythonDict(Points: TNormalizedPoints): string;
+var
+  StringArray : TStringArray = nil;
+  i : integer = 0;
+  j : integer = 0;
+begin
+  SetLength(StringArray, Length(Points)*2);
+  repeat
+    StringArray[j] :=
+      Format('X%s:%s', [(i+1).ToString, Points[i].X.ToDefaultString]);
+    StringArray[j+1] :=
+      Format('Y%s:%s', [(i+1).ToString, Points[i].Y.ToDefaultString]);
+    Inc(i);
+    Inc(j, 2);
+  until i > High(Points);
+
+  Result := '{' + String.Join(',', StringArray) + '}';
+end;
+
+procedure LogLine(Pairs: TTagPairs);
+var
+  i: Integer;
+  LastColumn : Integer;
+begin
+  LastColumn := High(Pairs);
+  for i := 0 to LastColumn-1 do begin
+    Write(OutputDataFile, Pairs[i].Value + TabDelimiter);
+  end;
+  Write(OutputDataFile, Pairs[LastColumn].Value + LineEnding);
+end;
+
+procedure LogLine(Dictionary: TPairsDictionary);
+begin
+  WriteLn(OutputDataFile, ToPythonDict(Dictionary));
+end;
+
+procedure LogLine(Points: TNormalizedPoints);
+begin
+  WriteLn(OutputDataFile, ToPythonDict(Points));
+end;
+
+procedure BeginUpdateData;
+begin
+  AssignFile(OutputDataFile, DataFilename);
+  System.Rewrite(OutputDataFile);
+  {$IF FPC_FULLVERSION >= 30200}
+  SetTextCodePage(OutputDataFile, CP_UTF8);
+  {$ELSE}
+  SetTextCodePage(OutputDataFile, 65001);
+  {$ENDIF}
+  WriteLn(OutputDataFile, DataHeader);
+end;
+
+procedure EndUpdateData;
+begin
+  System.Close(OutputDataFile);
+end;
+
+procedure FlushToDataFile;
+begin
+  System.Flush(OutputDataFile);
+end;
+
+end.
+

--- a/src/opengaze.logger.gaze.pas
+++ b/src/opengaze.logger.gaze.pas
@@ -1,0 +1,118 @@
+{
+  fpc-opengaze
+  Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU General Public License (GPL v3.0).
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit opengaze.logger.gaze;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, opengaze.types, opengaze.events;
+
+type
+
+  { TOpenGazeLogger }
+
+  TOpenGazeLogger = class
+  private
+    FEvents : TOpenGazeEvents;
+    FFilename: string;
+    FHeader: string;
+    FOnDataReceived: TGazeDataEvent;
+    FOutputDataFile : TextFile;
+    FDataReceivedEvent : TGazeDataEvent;
+    function GetHeader: string;
+    procedure DoNothing(Sender: TObject; RawTag: TRawTag);
+    procedure LogLine(Sender: TObject; RawTag : TRawTag);
+    procedure SetOnDataReceived(AValue: TGazeDataEvent);
+  public
+    constructor Create(AEvents : TOpenGazeEvents);
+    procedure BeginUpdateData;
+    procedure EndUpdateData;
+    procedure FlushToDataFile;
+    property DataReceivedEvent : TGazeDataEvent read FDataReceivedEvent;
+    property Header : string read GetHeader;
+    property Filename : string read FFilename write FFilename;
+    property OnDataReceived : TGazeDataEvent read FOnDataReceived write SetOnDataReceived;
+  end;
+
+implementation
+
+uses opengaze.commands;
+
+const
+  TabDelimiter = #9;
+
+{ TOpenGazeLogger }
+
+constructor TOpenGazeLogger.Create(AEvents: TOpenGazeEvents);
+begin
+  inherited Create;
+  FEvents := AEvents;
+  FDataReceivedEvent := @LogLine;
+  FOnDataReceived := @DoNothing;
+  FFilename := 'default_log.txt';
+end;
+
+procedure TOpenGazeLogger.LogLine(Sender: TObject; RawTag: TRawTag);
+var
+  i: Integer;
+  LastColumn : Integer;
+begin
+  LastColumn := High(RawTag.Pairs);
+  for i := 0 to LastColumn-1 do begin
+    Write(FOutputDataFile, RawTag.Pairs[i].Value + TabDelimiter);
+  end;
+  Write(FOutputDataFile, RawTag.Pairs[LastColumn].Value + LineEnding);
+  FOnDataReceived(Sender, RawTag);
+end;
+
+procedure TOpenGazeLogger.SetOnDataReceived(AValue: TGazeDataEvent);
+begin
+  if FOnDataReceived = AValue then Exit;
+  FOnDataReceived := AValue;
+end;
+
+function TOpenGazeLogger.GetHeader: string;
+begin
+  Result := GetDataHeader;
+end;
+
+procedure TOpenGazeLogger.DoNothing(Sender: TObject; RawTag: TRawTag);
+begin
+  { do nothing }
+end;
+
+procedure TOpenGazeLogger.BeginUpdateData;
+begin
+  AssignFile(FOutputDataFile, FFilename);
+  System.Rewrite(FOutputDataFile);
+  {$IF FPC_FULLVERSION >= 30200}
+  SetTextCodePage(FOutputDataFile, CP_UTF8);
+  {$ELSE}
+  SetTextCodePage(OutputDataFile, 65001);
+  {$ENDIF}
+  WriteLn(FOutputDataFile, GetDataHeader);
+  FEvents.OnDataReceived := DataReceivedEvent;
+end;
+
+procedure TOpenGazeLogger.EndUpdateData;
+begin
+  FEvents.OnDataReceived := @DoNothing;
+  System.Close(FOutputDataFile);
+end;
+
+procedure TOpenGazeLogger.FlushToDataFile;
+begin
+  System.Flush(FOutputDataFile);
+end;
+
+end.
+

--- a/src/opengaze.logger.information.pas
+++ b/src/opengaze.logger.information.pas
@@ -1,0 +1,63 @@
+{
+  fpc-opengaze
+  Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU General Public License (GPL v3.0).
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit opengaze.logger.information;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, opengaze.types;
+
+procedure LogLine(Title, Value : string);
+procedure BeginUpdateData;
+procedure EndUpdateData;
+procedure FlushToDataFile;
+
+var
+  DataHeader : string;
+  DataFilename : string = 'default_information_log.txt';
+
+implementation
+
+uses opengaze.helpers;
+
+var
+  OutputDataFile : TextFile;
+
+procedure LogLine(Title, Value: string);
+begin
+  WriteLn(OutputDataFile, Title + ':' + Value);
+end;
+
+procedure BeginUpdateData;
+begin
+  AssignFile(OutputDataFile, DataFilename);
+  System.Rewrite(OutputDataFile);
+  {$IF FPC_FULLVERSION >= 30200}
+  SetTextCodePage(OutputDataFile, CP_UTF8);
+  {$ELSE}
+  SetTextCodePage(OutputDataFile, 65001);
+  {$ENDIF}
+  WriteLn(OutputDataFile, DataHeader);
+end;
+
+procedure EndUpdateData;
+begin
+  System.Close(OutputDataFile);
+end;
+
+procedure FlushToDataFile;
+begin
+  System.Flush(OutputDataFile);
+end;
+
+end.
+

--- a/src/opengaze.socket.pas
+++ b/src/opengaze.socket.pas
@@ -34,6 +34,7 @@ type
     FLastBlockedCommand: string;
     function GetConnected: Boolean;
     function GetIsBlocked: Boolean;
+    function GetIsLocal: Boolean;
     procedure SeTOpenGazeServer(AValue: TOpenGazeServer);
     procedure SetIsBlocked(AValue: Boolean);
     function Block(TimeOut : integer) : TWaitResult;
@@ -48,6 +49,7 @@ type
       Timeout : Integer = MaxInt); overload;
     function Receive(Timeout: Integer = MaxInt): string;
     property IP: string read FIP write FIP;
+    property IsLocal : Boolean read GetIsLocal;
     property Port: string read FPort write FPort;
     property Lock: TCriticalSection read FLock;
     property Event: TEvent read FEvent write FEvent;
@@ -82,6 +84,11 @@ begin
   finally
     FLock.Release;
   end;
+end;
+
+function TOpenGazeSocket.GetIsLocal: Boolean;
+begin
+  Result := FIP = '127.0.0.1';
 end;
 
 procedure TOpenGazeSocket.SeTOpenGazeServer(AValue: TOpenGazeServer);

--- a/src/opengaze.worker.pas
+++ b/src/opengaze.worker.pas
@@ -1,3 +1,12 @@
+{
+  fpc-opengaze
+  Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU General Public License (GPL v3.0).
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
 unit opengaze.worker;
 
 {$mode ObjFPC}{$H+}

--- a/utils/animation.pas
+++ b/utils/animation.pas
@@ -21,7 +21,7 @@ type
 
   TProcedureOfObject = procedure of object;
 
-  TPaintingState = (Waiting, PaintingPointDelay, PaintingPointDuration);
+  TPaintingState = (Waiting, PaintingOnset, PaintingPointDelay, PaintingPointDuration);
 
   { TAnimation }
 
@@ -66,6 +66,7 @@ type
       procedure PaintBackPoint(X, Y : Integer);
       procedure Reset;
       procedure SetSize(Width, Height : Integer);
+      procedure StartOnSet;
       procedure StartPointDuration;
       procedure StartPointAnimation;
       procedure EndPointTimeout;
@@ -192,6 +193,10 @@ begin
       DrawGaze;
     end;
 
+    PaintingOnset : begin
+      DrawCalibrationPoint(clRed);
+    end;
+
     PaintingPointDelay : begin
       DrawCalibrationPoint(clBlack);
     end;
@@ -311,6 +316,14 @@ begin
   FBitmap.SetSize(Width, Height);
   FBitmapBack.SetSize(Width, Height);
   ClearBackground;
+end;
+
+procedure TAnimation.StartOnSet;
+begin
+  FIndex := Low(FTargets);
+  FTargetA := FTargets[FIndex];
+  FState := PaintingOnset;
+  Paint;
 end;
 
 procedure TAnimation.StartPointAnimation;

--- a/utils/choreographies.pas
+++ b/utils/choreographies.pas
@@ -44,6 +44,7 @@ type
     procedure Start;
     procedure Stop;
     procedure SetPoints(NormalizedPoints : TNormalizedPoints);
+    procedure SetScreen(AX, AY, AW, AH : integer);
     function GetPoints(AN: integer = 3;
       Coreography: TCoreography = nil): TNormalizedPoints;
     property Animation : TAnimation read FAnimation;
@@ -173,6 +174,11 @@ begin
       Point.X.Denormalize(Width),
       Point.Y.Denormalize(Height));
   end;
+end;
+
+procedure TCalibrationChoreography.SetScreen(AX, AY, AW, AH: integer);
+begin
+  FBackground.BoundsRect := Rect(AX, AY, AX+AW, AY+AH);
 end;
 
 initialization

--- a/utils/choreographies.pas
+++ b/utils/choreographies.pas
@@ -98,6 +98,7 @@ end;
 procedure TCalibrationChoreography.Show;
 begin
   FBackground.Show;
+  FAnimation.StartOnSet;
 end;
 
 procedure TCalibrationChoreography.Hide;

--- a/utils/forms.background.pas
+++ b/utils/forms.background.pas
@@ -79,6 +79,7 @@ begin
   Color := 0;
   Width := Screen.Width;
   Height := Screen.Height;
+  Cursor := -1;
 
   FForm := TForm.CreateNew(nil);
   FForm.Width := Screen.Width;

--- a/utils/windows.timestamps.pas
+++ b/utils/windows.timestamps.pas
@@ -1,5 +1,5 @@
 {
-  fpc-OpenGaze
+  fpc-opengaze
   Copyright (C) 2024 Carlos Rafael Fernandes Picanço.
 
   The present file is distributed under the terms of the GNU General Public License (GPL v3.0).


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Enhanced the client form with new components for custom calibration and IP input.
- Refactored calibration and recording functionalities to include logging and timer enhancements.
- Introduced new units for logging calibration, gaze, and information data.
- Added new commands and constants for device information retrieval.
- Improved socket and client functionalities with connection checks and setup methods.
- Updated form layout and project settings for better usability and maintenance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>forms.main.pas</strong><dd><code>Enhance client form with custom calibration and IP input</code>&nbsp; </dd></summary>
<hr>

examples/client/forms.main.pas

<li>Added <code>CheckBoxUseCustomCalibration</code> and <code>EditIP</code> components.<br> <li> Modified calibration and recording procedures for new components.<br> <li> Implemented <code>CheckBoxUseRemoteServerChange</code> procedure.<br>


</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-b4ef7210f161cef0d5ef6600913473df2efa4a739b04312ac92abae7cb85a401">+28/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.base.pas</strong><dd><code>Introduce RequestKey function for simplified command requests</code></dd></summary>
<hr>

src/opengaze.base.pas

- Added `RequestKey` function for command requests.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-bf5835dc6ce8cbc5ed78cc9b7d9b772a42db2ae558cf9b6c0b774aa50bc442a2">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.calibration.pas</strong><dd><code>Refactor calibration with logging and timer enhancements</code>&nbsp; </dd></summary>
<hr>

src/opengaze.calibration.pas

<li>Added logging and timer functionalities.<br> <li> Refactored calibration start/stop methods.<br> <li> Introduced new properties and methods for calibration control.<br>


</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-2522510bca0cf5877887fbd31c719eb3db17f2fdc83cb91d924f69960ea4c2cd">+94/-51</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.client.pas</strong><dd><code>Add connection status check to client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.client.pas

- Added `Connected` function to check connection status.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-7cd47b50cd844cfda435b8577c569f6eedcb756bca0573dd65ec39410282eac6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.commands.pas</strong><dd><code>Extend commands with information retrieval capabilities</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.commands.pas

- Added `TInformationCommands` for retrieving device information.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-9260b10aae74607138976517e29963c58da4fa1e5c7fbeb5976fe6afd12098d7">+48/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.constants.pas</strong><dd><code>Add constants for camera dimensions and frequency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.constants.pas

- Added new constants for camera and frequency parameters.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-bdb23722a2d63c38d43e0cb3d62e7dcc0bf04730a7412fd253da334b980876b1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.control.pas</strong><dd><code>Integrate information management and enhance control client</code></dd></summary>
<hr>

src/opengaze.control.pas

<li>Integrated <code>TOpenGazeInformation</code> for device info management.<br> <li> Added methods for calibration and recording setup.<br>


</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-a02aaed0b7906e00ddd764dbc3afc88d9c99e90eddc45ec062ccec9bc0e92283">+55/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.events.pas</strong><dd><code>Simplify event processing by removing logger dependency</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.events.pas

- Removed logger usage from events processing.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-dd3f5747a5a1e1a0c3cc08487ead094cec340a9288ac4e43514099eab001a223">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.helpers.pas</strong><dd><code>Enhance float helper with default string conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.helpers.pas

- Added `ToDefaultString` method to `TFloatOpenGazeHelper`.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-36776658dcaaca68d8ae153b8f8281328eed68fde90e1903dfce98cb19826934">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.information.pas</strong><dd><code>Introduce information unit for gaze data logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.information.pas

- New unit for handling gaze information logging.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-4cc8bda0bd43ff2ae13691130cf7fd8cdbe94da562657a8f0fe65a05866c1176">+145/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.logger.calibration.pas</strong><dd><code>Add calibration logger for data tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.logger.calibration.pas

- New unit for calibration data logging.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-11dcdd0274e97554576b77ecbeea281ebe37f8e0e0245c3e637ccdc95d6cfa6e">+122/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.logger.gaze.pas</strong><dd><code>Implement gaze logger for recording gaze data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.logger.gaze.pas

- New unit for gaze data logging.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-ef2b0098624865dec877104fdaef99249588cae4d07bd0e47a20d9d12d3c76cc">+118/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.logger.information.pas</strong><dd><code>Create logger for information data management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.logger.information.pas

- New unit for logging information data.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-2ca51d6520ee6a1f235fd9cee58b5924a6119290369f4c52c1e34d151e7083c3">+63/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.recording.pas</strong><dd><code>Enhance recording with integrated logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.recording.pas

<li>Integrated logger for recording data.<br> <li> Added methods for data file setup.<br>


</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-c5a4bc02476b392f3e7e7ab9794576f8cba88c784730197c668d64abecd5bc0d">+27/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>opengaze.socket.pas</strong><dd><code>Add local connection check to socket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/opengaze.socket.pas

- Added `GetIsLocal` function to determine local connection.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-93aebf3f8f6ade5a9d26e1a71f4052e196fe34e813458e00dfd772d98ed27249">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>animation.pas</strong><dd><code>Extend animation states with onset painting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/animation.pas

- Added `PaintingOnset` state to `TPaintingState`.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-3ceeb6d9f38e0bdf5d411a006657fd462de00c9ab44a2538c364ab627add1c72">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>choreographies.pas</strong><dd><code>Add screen dimension setting to choreography</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/choreographies.pas

- Added method to set screen dimensions.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-20c137d4b339985ad310e84fe8746167efb3cacda2da5fe1cc2e62c2992d07bc">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>forms.background.pas</strong><dd><code>Hide cursor in background form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/forms.background.pas

- Set cursor to invisible in background form.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-ba49f16b07387e13b4324b55c09736ba40c194d29796fbc5c63555df1c4cee4d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>forms.main.lfm</strong><dd><code>Update form layout with additional controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/client/forms.main.lfm

- Updated form layout with new components.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-3ae709479ee31b3558ddebdbf1930bc9aa032b3e2682a0aabe5caebd2fd70a20">+62/-41</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>windows.timestamps.pas</strong><dd><code>Fix copyright header in timestamps unit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/windows.timestamps.pas

- Corrected copyright header.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-69651e12e3caa10ead3de205672e23c1f33e986bdbb69b3a4f19176141207c21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>opengaze_client.lpi</strong><dd><code>Clean up project file settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/client/opengaze_client.lpi

- Removed unused icon and debug defines.



</details>


  </td>
  <td><a href="https://github.com/cpicanco/fpc-opengaze/pull/1/files#diff-190e9e2df7421ba9356d6dc80ecf1846bce927ca963dc011e386ef8672e29296">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

